### PR TITLE
fix: update look for context before sending out a reply

### DIFF
--- a/src/text/lookfor.js
+++ b/src/text/lookfor.js
@@ -73,6 +73,14 @@ export async function lookfor(msg, match) {
     let caption = await getImageCaption(prompt, `Here's ${currentContext.query}`)
     caption = `<a href='${bingImage.contentUrl}'>Download</a> / <a href='${bingImage.hostPageUrl}'>Source</a>${caption}`
 
+    const nextContext = {
+      ...currentContext,
+      index: currentContext.index + 1,
+    }
+
+    // update context with last query
+    lookForContext.set(contextKey, nextContext)
+
     let response = null
     switch (bingImage.encodingFormat) {
       case "animatedgif": {
@@ -90,9 +98,9 @@ export async function lookfor(msg, match) {
       }
     }
 
+    // update context with phoebe reply
     lookForContext.set(contextKey, {
-      ...currentContext,
-      index: currentContext.index + 1,
+      ...nextContext,
       respondedWith: response.message_id,
     })
   } catch (err) {

--- a/src/text/lookfor.js
+++ b/src/text/lookfor.js
@@ -115,13 +115,12 @@ export async function lookfor(msg, match) {
 export async function undo(msg) {
   const contextKey = `${msg.chat.id}-${msg.from.username}`
 
-  if (!lookForContext.has(contextKey)) {
-    await telegramBot.sendMessage(msg.chat.id, "¯\\_(ツ)_/¯")
-    return
-  }
-
   try {
-    const { respondedWith } = lookForContext.get(contextKey)
+    const { respondedWith } = lookForContext.has(contextKey) ? lookForContext.get(contextKey) : {}
+    if (!respondedWith) {
+      telegramBot.sendMessage(msg.chat.id, "¯\\_(ツ)_/¯")
+      return
+    }
     await telegramBot.deleteMessage(msg.chat.id, respondedWith)
 
     const openAI = getOpenAI()


### PR DESCRIPTION
update context twice:
+ 1st time before sending a reply, to update context no matter if we are able to send the telegram message
+ 2nd time after reply was sent out, to support for phoebe undo
Also fixed:
+ phoebe undo crashing when `respondedWith` was undefined.